### PR TITLE
Add documentation for agents and prompts

### DIFF
--- a/docs/docs/agents_and_prompts.md
+++ b/docs/docs/agents_and_prompts.md
@@ -1,0 +1,102 @@
+# Agenten und Prompts in GPT Researcher
+
+## Verwendete Agenten in GPT Researcher
+
+GPT Researcher nutzt verschiedene Agenten, um unterschiedliche Aufgaben zu erfüllen. Jeder Agent hat eine spezifische Rolle und ist darauf ausgelegt, einen bestimmten Aspekt des Forschungsprozesses zu bearbeiten. Hier sind die Hauptagenten, die in GPT Researcher verwendet werden:
+
+1. **Researcher Agent**: Dieser Agent ist verantwortlich für die Durchführung einer gründlichen Recherche zu einem gegebenen Thema. Er unterteilt die Hauptfrage in Unterthemen, führt gezielte Recherchen zu jedem Unterthema durch und erstellt Entwurfsabschnitte für den Bericht.
+
+2. **Editor Agent**: Der Editor-Agent plant die Gliederung und Struktur des Berichts basierend auf der anfänglichen Recherche. Er stellt sicher, dass der Bericht gut organisiert ist und alle relevanten Aspekte des Themas abdeckt.
+
+3. **Reviewer Agent**: Dieser Agent validiert die Richtigkeit der Forschungsergebnisse basierend auf einer Reihe von Kriterien. Er gibt Feedback, um die Genauigkeit und Zuverlässigkeit der Informationen sicherzustellen.
+
+4. **Revisor Agent**: Der Revisor-Agent überarbeitet die Forschungsergebnisse basierend auf dem Feedback des Reviewers. Er stellt sicher, dass der endgültige Bericht genau und umfassend ist.
+
+5. **Writer Agent**: Der Writer-Agent erstellt und schreibt den endgültigen Bericht, einschließlich einer Einleitung, eines Fazits und eines Abschnitts mit Referenzen. Er stellt sicher, dass der Bericht gut geschrieben ist und dem angegebenen Format folgt.
+
+6. **Publisher Agent**: Dieser Agent ist verantwortlich für die Veröffentlichung des endgültigen Berichts in verschiedenen Formaten wie PDF, Docx und Markdown.
+
+## Verwendeter Prompt zur Generierung von Berichten
+
+Der zur Generierung von Berichten in GPT Researcher verwendete Prompt ist darauf ausgelegt, sicherzustellen, dass der Bericht detailliert, informativ und gut strukturiert ist. Hier ist ein Beispiel für den verwendeten Prompt:
+
+```
+Information: "{context}"
+---
+Verwenden Sie die obigen Informationen, um die folgende Frage oder Aufgabe in einem detaillierten Bericht zu beantworten: "{question}" --
+Der Bericht sollte sich auf die Beantwortung der Frage konzentrieren, gut strukturiert, informativ, tiefgehend und umfassend sein, mit Fakten und Zahlen, falls verfügbar, und mindestens {total_words} Wörter umfassen.
+Sie sollten sich bemühen, den Bericht so lang wie möglich zu schreiben, indem Sie alle relevanten und notwendigen Informationen verwenden.
+
+Bitte befolgen Sie alle folgenden Richtlinien in Ihrem Bericht:
+- Sie MÜSSEN Ihre eigene konkrete und gültige Meinung basierend auf den gegebenen Informationen bestimmen. Vermeiden Sie allgemeine und bedeutungslose Schlussfolgerungen.
+- Sie MÜSSEN den Bericht mit Markdown-Syntax und im {report_format}-Format schreiben.
+- Sie MÜSSEN die Relevanz, Zuverlässigkeit und Bedeutung der von Ihnen verwendeten Quellen priorisieren. Wählen Sie vertrauenswürdige Quellen gegenüber weniger zuverlässigen.
+- Sie müssen auch neue Artikel gegenüber älteren Artikeln priorisieren, wenn die Quelle vertrauenswürdig ist.
+- Verwenden Sie In-Text-Zitationsreferenzen im {report_format}-Format und machen Sie sie mit Markdown-Hyperlink am Ende des Satzes oder Absatzes, der sie referenziert, wie folgt: ([In-Text-Zitation](url)).
+- Vergessen Sie nicht, am Ende des Berichts eine Referenzliste im {report_format}-Format und vollständige URL-Links ohne Hyperlinks hinzuzufügen.
+- {reference_prompt}
+- {tone_prompt}
+
+Sie MÜSSEN den Bericht in der folgenden Sprache schreiben: {language}.
+Bitte geben Sie Ihr Bestes, dies ist sehr wichtig für meine Karriere.
+Gehen Sie davon aus, dass das aktuelle Datum {date.today()} ist.
+```
+
+## Wie man die Einstellungen ändert
+
+Sie können die Einstellungen von GPT Researcher ändern, indem Sie die Konfigurationsdatei anpassen oder Umgebungsvariablen setzen. Hier sind die wichtigsten Einstellungen, die Sie ändern können:
+
+1. **RETRIEVER**: Die Web-Suchmaschine, die zum Abrufen von Quellen verwendet wird. Optionen umfassen `tavily`, `duckduckgo`, `bing`, `google`, `searchapi`, `serper`, `searx` usw.
+
+2. **EMBEDDING**: Das verwendete Einbettungsmodell. Optionen umfassen `openai:text-embedding-3-small`, `ollama`, `huggingface`, `azure_openai`, `custom` usw.
+
+3. **FAST_LLM**: Der Modellname für schnelle LLM-Operationen wie Zusammenfassungen. Standard ist `openai:gpt-4o-mini`.
+
+4. **SMART_LLM**: Der Modellname für intelligente Operationen wie das Erstellen von Forschungsberichten und das Schließen von Argumenten. Standard ist `openai:gpt-4o`.
+
+5. **STRATEGIC_LLM**: Der Modellname für strategische Operationen wie das Erstellen von Forschungsplänen und -strategien. Standard ist `openai:o1-preview`.
+
+6. **LANGUAGE**: Die Sprache, die für den endgültigen Forschungsbericht verwendet werden soll. Standard ist `english`.
+
+7. **CURATE_SOURCES**: Ob Quellen für die Forschung kuratiert werden sollen. Standard ist `True`.
+
+8. **FAST_TOKEN_LIMIT**: Das maximale Token-Limit für schnelle LLM-Antworten. Standard ist `2000`.
+
+9. **SMART_TOKEN_LIMIT**: Das maximale Token-Limit für intelligente LLM-Antworten. Standard ist `4000`.
+
+10. **STRATEGIC_TOKEN_LIMIT**: Das maximale Token-Limit für strategische LLM-Antworten. Standard ist `4000`.
+
+11. **BROWSE_CHUNK_MAX_LENGTH**: Die maximale Länge von Textabschnitten, die in Webquellen durchsucht werden sollen. Standard ist `8192`.
+
+12. **SUMMARY_TOKEN_LIMIT**: Das maximale Token-Limit für die Erstellung von Zusammenfassungen. Standard ist `700`.
+
+13. **TEMPERATURE**: Die Abtasttemperatur für LLM-Antworten, typischerweise zwischen 0 und 1. Standard ist `0.55`.
+
+14. **TOTAL_WORDS**: Das Gesamtwortanzahl-Limit für Dokumentenerstellungs- oder -verarbeitungsaufgaben. Standard ist `800`.
+
+15. **REPORT_FORMAT**: Das bevorzugte Format für die Berichtserstellung. Optionen umfassen `APA`, `MLA`, `CMS`, `Harvard style`, `IEEE` usw.
+
+16. **MAX_ITERATIONS**: Die maximale Anzahl von Iterationen für Prozesse wie die Abfrageerweiterung oder die Verfeinerung der Suche. Standard ist `3`.
+
+17. **AGENT_ROLE**: Die Rolle des Agenten. Dies könnte verwendet werden, um das Verhalten des Agenten basierend auf seinen zugewiesenen Rollen anzupassen.
+
+18. **MAX_SUBTOPICS**: Die maximale Anzahl von Unterthemen, die generiert oder berücksichtigt werden sollen. Standard ist `3`.
+
+19. **SCRAPER**: Der Web-Scraper, der zum Sammeln von Informationen verwendet wird. Standard ist `bs` (BeautifulSoup). Sie können auch `newspaper` verwenden.
+
+20. **DOC_PATH**: Der Pfad zum Lesen und Recherchieren lokaler Dokumente. Standard ist ein leerer String, der keinen angegebenen Pfad anzeigt.
+
+21. **USER_AGENT**: Der benutzerdefinierte User-Agent-String für Web-Crawling und Web-Anfragen.
+
+22. **MEMORY_BACKEND**: Das Backend, das für Speicheroperationen verwendet wird, wie z.B. die lokale Speicherung temporärer Daten. Standard ist `local`.
+
+Um diese Einstellungen zu ändern, können Sie entweder die Konfigurationsdatei anpassen oder die entsprechenden Umgebungsvariablen setzen. Zum Beispiel, um die Suchmaschine und das Berichtsformat zu ändern, können Sie die folgenden Umgebungsvariablen setzen:
+
+```bash
+export RETRIEVER=bing
+export REPORT_FORMAT=IEEE
+```
+
+Bitte beachten Sie, dass Sie möglicherweise zusätzliche Umgebungsvariablen exportieren und API-Schlüssel für andere unterstützte Such-Retriever und LLM-Anbieter erhalten müssen. Folgen Sie Ihren Konsolenprotokollen für weitere Unterstützung.
+
+Für weitere Informationen zur zusätzlichen LLM-Unterstützung können Sie die [Dokumentation](https://docs.gptr.dev/docs/gpt-researcher/llms/llms) einsehen.

--- a/docs/docs/getting-started/introduction.md
+++ b/docs/docs/getting-started/introduction.md
@@ -1,0 +1,61 @@
+# Einführung
+
+[![Offizielle Website](https://img.shields.io/badge/Official%20Website-gptr.dev-teal?style=for-the-badge&logo=world&logoColor=white)](https://gptr.dev)
+[![Discord Follow](https://dcbadge.vercel.app/api/server/QgZXvJAccX?style=for-the-badge&theme=clean-inverted)](https://discord.gg/QgZXvJAccX)
+
+[![GitHub Repo stars](https://img.shields.io/github/stars/assafelovic/gpt-researcher?style=social)](https://github.com/assafelovic/gpt-researcher)
+[![Twitter Follow](https://img.shields.io/twitter/follow/assaf_elovic?style=social)](https://twitter.com/assaf_elovic)
+[![PyPI version](https://badge.fury.io/py/gpt-researcher.svg)](https://badge.fury.io/py/gpt-researcher)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/assafelovic/gpt-researcher/blob/master/docs/docs/examples/pip-run.ipynb)
+
+**[GPT Researcher](https://gptr.dev) ist ein autonomer Agent, der für umfassende Online-Recherchen zu verschiedenen Aufgaben entwickelt wurde.** 
+
+Der Agent kann detaillierte, faktenbasierte und unvoreingenommene Forschungsberichte erstellen, mit Anpassungsoptionen für die Fokussierung auf relevante Ressourcen, Gliederungen und Lektionen. Inspiriert von den jüngsten [Plan-and-Solve](https://arxiv.org/abs/2305.04091) und [RAG](https://arxiv.org/abs/2005.11401) Papieren, adressiert GPT Researcher Probleme wie Geschwindigkeit, Determinismus und Zuverlässigkeit, indem er eine stabilere Leistung und erhöhte Geschwindigkeit durch parallelisierte Agentenarbeit bietet, im Gegensatz zu synchronen Operationen.
+
+## Warum GPT Researcher?
+
+- Um objektive Schlussfolgerungen für manuelle Forschungsaufgaben zu ziehen, kann es Zeit in Anspruch nehmen, manchmal Wochen, um die richtigen Ressourcen und Informationen zu finden.
+- Aktuelle LLMs sind auf vergangene und veraltete Informationen trainiert, mit hohen Risiken von Halluzinationen, was sie für Forschungsaufgaben fast irrelevant macht.
+- Aktuelle LLMs sind auf kurze Token-Ausgaben beschränkt, die nicht ausreichen, um lange detaillierte Forschungsberichte (über 2.000 Wörter) zu erstellen.
+- Lösungen, die Websuche ermöglichen (wie ChatGPT + Web Plugin), berücksichtigen nur begrenzte Ressourcen und Inhalte, die in einigen Fällen zu oberflächlichen Schlussfolgerungen oder voreingenommenen Antworten führen.
+- Die Verwendung nur einer Auswahl von Ressourcen kann zu Voreingenommenheit bei der Bestimmung der richtigen Schlussfolgerungen für Forschungsfragen oder -aufgaben führen. 
+
+## Architektur
+Die Hauptidee ist es, "Planungs-" und "Ausführungs-" Agenten auszuführen, wobei der Planer Fragen zur Recherche generiert und die Ausführungsagenten die relevantesten Informationen basierend auf jeder generierten Forschungsfrage suchen. Schließlich filtert und aggregiert der Planer alle relevanten Informationen und erstellt einen Forschungsbericht. <br /> <br /> 
+Die Agenten nutzen sowohl gpt-4o-mini als auch gpt-4o (128K Kontext), um eine Forschungsaufgabe abzuschließen. Wir optimieren die Kosten, indem wir jeden nur bei Bedarf verwenden. **Die durchschnittliche Forschungsaufgabe dauert etwa 3 Minuten und kostet ~0,1 $.**
+
+<div align="center">
+<img align="center" height="600" src="https://github.com/assafelovic/gpt-researcher/assets/13554167/4ac896fd-63ab-4b77-9688-ff62aafcc527" />
+</div>
+
+
+Genauer gesagt:
+* Erstellen Sie einen domänenspezifischen Agenten basierend auf der Forschungsfrage oder -aufgabe.
+* Generieren Sie eine Reihe von Forschungsfragen, die zusammen eine objektive Meinung zu einer gegebenen Aufgabe bilden. 
+* Für jede Forschungsfrage einen Crawler-Agenten auslösen, der Online-Ressourcen nach Informationen durchsucht, die für die gegebene Aufgabe relevant sind.
+* Für jede gesammelte Ressource eine Zusammenfassung basierend auf relevanten Informationen erstellen und die Quellen im Auge behalten.
+* Schließlich alle zusammengefassten Quellen filtern und aggregieren und einen abschließenden Forschungsbericht erstellen.
+
+## Demo
+<iframe height="400" width="700" src="https://github.com/assafelovic/gpt-researcher/assets/13554167/a00c89a6-a295-4dd0-b58d-098a31c40fda" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+
+## Tutorials
+ - [Video Tutorial Series](https://www.youtube.com/playlist?list=PLUGOUZPIB0F-qv6MvKq3HGr0M_b3U2ATv)
+ - [How it Works](https://medium.com/better-programming/how-i-built-an-autonomous-ai-agent-for-online-research-93435a97c6c)
+ - [How to Install](https://www.loom.com/share/04ebffb6ed2a4520a27c3e3addcdde20?sid=da1848e8-b1f1-42d1-93c3-5b0b9c3b24ea)
+ - [Live Demo](https://www.loom.com/share/6a3385db4e8747a1913dd85a7834846f?sid=a740fd5b-2aa3-457e-8fb7-86976f59f9b8)
+ - [Homepage](https://gptr.dev)
+
+## Funktionen
+- 📝 Generieren von Forschungs-, Gliederungs-, Ressourcen- und Lektionenberichten
+- 📜 Kann lange und detaillierte Forschungsberichte (über 2.000 Wörter) erstellen
+- 🌐 Aggregiert über 20 Webquellen pro Forschung, um objektive und faktenbasierte Schlussfolgerungen zu ziehen
+- 🖥️ Enthält eine benutzerfreundliche Weboberfläche (HTML/CSS/JS)
+- 🔍 Durchsucht Webquellen mit JavaScript-Unterstützung
+- 📂 Behält den Überblick und den Kontext der besuchten und verwendeten Webquellen
+- 📄 Exportiert Forschungsberichte in PDF, Word und mehr...
+
+Lass uns [hier](/docs/gpt-researcher/getting-started/getting-started) loslegen!
+
+## Zusätzliche Ressourcen
+- [Agenten und Prompts](../agents_and_prompts.md)

--- a/docs/docs/sidebar.json
+++ b/docs/docs/sidebar.json
@@ -1,0 +1,78 @@
+{
+  "docs": {
+    "Introduction": [
+      "getting-started/introduction",
+      "getting-started/how-to-choose",
+      "getting-started/getting-started",
+      "getting-started/getting-started-with-docker",
+      "getting-started/linux-deployment",
+      "getting-started/cli"
+    ],
+    "GPT Researcher": [
+      "gpt-researcher/gptr/config",
+      "gpt-researcher/gptr/example",
+      "gpt-researcher/gptr/npm-package",
+      "gpt-researcher/gptr/pip-package",
+      "gpt-researcher/gptr/querying-the-backend",
+      "gpt-researcher/gptr/scraping",
+      "gpt-researcher/gptr/troubleshooting",
+      "gpt-researcher/gptr/automated-tests",
+      "gpt-researcher/context/data-ingestion",
+      "gpt-researcher/context/filtering-by-domain",
+      "gpt-researcher/context/local-docs",
+      "gpt-researcher/context/tailored-research",
+      "gpt-researcher/context/vector-stores",
+      "gpt-researcher/frontend/discord-bot",
+      "gpt-researcher/frontend/introduction",
+      "gpt-researcher/frontend/nextjs-frontend",
+      "gpt-researcher/frontend/vanilla-js-frontend",
+      "gpt-researcher/frontend/visualizing-websockets",
+      "gpt-researcher/getting-started/cli",
+      "gpt-researcher/getting-started/getting-started-with-docker",
+      "gpt-researcher/getting-started/getting-started",
+      "gpt-researcher/getting-started/how-to-choose",
+      "gpt-researcher/getting-started/introduction",
+      "gpt-researcher/getting-started/linux-deployment",
+      "gpt-researcher/handling-logs/all-about-logs",
+      "gpt-researcher/handling-logs/langsmith-logs",
+      "gpt-researcher/handling-logs/simple-logs-example",
+      "gpt-researcher/llms/llms",
+      "gpt-researcher/llms/running-with-azure",
+      "gpt-researcher/llms/running-with-ollama",
+      "gpt-researcher/llms/supported-llms",
+      "gpt-researcher/llms/testing-your-llm",
+      "gpt-researcher/multi_agents/langgraph",
+      "gpt-researcher/search-engines/retrievers",
+      "gpt-researcher/search-engines/test-your-retriever"
+    ],
+    "Examples": [
+      "examples/detailed_report",
+      "examples/examples",
+      "examples/hybrid_research",
+      "examples/pip-run",
+      "examples/sample_report",
+      "examples/sample_sources_only"
+    ],
+    "Reference": [
+      "reference/config/config",
+      "reference/config/singleton",
+      "reference/processing/html",
+      "reference/processing/text"
+    ],
+    "Contribute": [
+      "contribute"
+    ],
+    "FAQ": [
+      "faq"
+    ],
+    "Roadmap": [
+      "roadmap"
+    ],
+    "Welcome": [
+      "welcome"
+    ],
+    "Agenten und Prompts": [
+      "agents_and_prompts"
+    ]
+  }
+}


### PR DESCRIPTION
Add a new Markdown file explaining the agents used, the prompt used, and how to change the settings in GPT Researcher.

* Add `docs/docs/agents_and_prompts.md` with detailed explanations of the agents used, the prompt used for generating reports, and instructions on how to change the settings.
* Add a link to the new file in `docs/docs/getting-started/introduction.md`.
* Update `docs/docs/sidebar.json` to include an entry for the new file `agents_and_prompts.md` in the sidebar.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SebGK/gpt-researcher/pull/1?shareId=95ba8e26-7d12-4ae1-992c-dee65f44e1f5).